### PR TITLE
[FAB-1009] [Minor] move logging out of error log

### DIFF
--- a/lib/puppet/parser/functions/get_bulkdeny_array_data.rb
+++ b/lib/puppet/parser/functions/get_bulkdeny_array_data.rb
@@ -60,7 +60,7 @@ module Puppet::Parser::Functions
         elsif response.code === "404"
             # drop a message to the logs if no bulkdeny bundles has been found
             # that's non-breaking
-            info("testsavadebug: No bulk deny bundles with prefix (#{prefix}) in Consul. This might be expected.")
+            info("No bulk deny bundles with prefix (#{prefix}) in Consul. This might be expected.")
     
             # return empty hash
             {}

--- a/lib/puppet/parser/functions/get_bulkdeny_array_data.rb
+++ b/lib/puppet/parser/functions/get_bulkdeny_array_data.rb
@@ -60,7 +60,7 @@ module Puppet::Parser::Functions
         elsif response.code === "404"
             # drop a message to the logs if no bulkdeny bundles has been found
             # that's non-breaking
-            p "No bulk deny bundles with prefix (#{prefix}) in Consul. This might be expected."
+            p "testsava: No bulk deny bundles with prefix (#{prefix}) in Consul. This might be expected."
     
             # return empty hash
             {}

--- a/lib/puppet/parser/functions/get_bulkdeny_array_data.rb
+++ b/lib/puppet/parser/functions/get_bulkdeny_array_data.rb
@@ -46,10 +46,10 @@ module Puppet::Parser::Functions
                             end
                             ipsetsGroupedByRuleAndPriority[ipset_name] = ips
                         else
-                            p "Ipset #{ipset_name} has an invalid IP in its values. Skipping its processing.."   
+                            info("Ipset #{ipset_name} has an invalid IP in its values. Skipping its processing..")
                         end
                     else 
-                        p "Ipset #{ipset_name} is empty. Skipping its processing.."   
+                        info("Ipset #{ipset_name} is empty. Skipping its processing..")
                     end
                 end
     
@@ -60,7 +60,7 @@ module Puppet::Parser::Functions
         elsif response.code === "404"
             # drop a message to the logs if no bulkdeny bundles has been found
             # that's non-breaking
-            p "testsava: No bulk deny bundles with prefix (#{prefix}) in Consul. This might be expected."
+            info("testsavadebug: No bulk deny bundles with prefix (#{prefix}) in Consul. This might be expected.")
     
             # return empty hash
             {}

--- a/lib/puppet/parser/functions/get_table_data.rb
+++ b/lib/puppet/parser/functions/get_table_data.rb
@@ -49,15 +49,15 @@ module Puppet::Parser::Functions
 
                                 ipsetsGroupedByRuleAndPriority[ipset_name] << ip 
                             else
-                                p "Ipset #{ipset_name} has ip defined with rule that is not either 'accept' or 'drop'. It is '#{details["rule"]}'. Skipping its processing.."
+                                info("Ipset #{ipset_name} has ip defined with rule that is not either 'accept' or 'drop'. It is '#{details["rule"]}'. Skipping its processing..")
                             end
                         else
-                            p "Ipset #{ipset_name} has an invalid IP (#{ip}) as key. Skipping its processing.."   
+                            info("Ipset #{ipset_name} has an invalid IP (#{ip}) as key. Skipping its processing..")
                         end
                     end
                 end
             else
-                p "There is an Ipset with a wrong name that doesn't start with 'ipsets*'. This may be due to additional tenant-scoping. Skipping its processing"
+                info("There is an Ipset with a wrong name that doesn't start with 'ipsets*'. This may be due to additional tenant-scoping. Skipping its processing")
             end
         end
 
@@ -66,7 +66,7 @@ module Puppet::Parser::Functions
     elsif response.code === "404"
         # drop a message to the logs if no bundle has been found
         # that's non-breaking and expected for most roles
-        p "testsava: No bundle with ipsets (#{bundle}) in Consul. This might be expected."
+        info("testsavainfo: No bundle with ipsets (#{bundle}) in Consul. This might be expected.")
 
         # return empty hash
         {}

--- a/lib/puppet/parser/functions/get_table_data.rb
+++ b/lib/puppet/parser/functions/get_table_data.rb
@@ -33,7 +33,10 @@ module Puppet::Parser::Functions
                 if !ipset_value.nil?
 
                     ipset_value.each do |ip, details|  
-                    
+                        
+                        # removes leading and trailing whitespaces for resilience
+                        ip = ip.strip
+                        
                         if function_validate_cidr([ip])
 
                             if details["rule"] == "accept" || details["rule"] == "drop" 

--- a/lib/puppet/parser/functions/get_table_data.rb
+++ b/lib/puppet/parser/functions/get_table_data.rb
@@ -66,7 +66,7 @@ module Puppet::Parser::Functions
     elsif response.code === "404"
         # drop a message to the logs if no bundle has been found
         # that's non-breaking and expected for most roles
-        info("testsavainfo: No bundle with ipsets (#{bundle}) in Consul. This might be expected.")
+        info("No bundle with ipsets (#{bundle}) in Consul. This might be expected.")
 
         # return empty hash
         {}

--- a/lib/puppet/parser/functions/get_table_data.rb
+++ b/lib/puppet/parser/functions/get_table_data.rb
@@ -66,7 +66,7 @@ module Puppet::Parser::Functions
     elsif response.code === "404"
         # drop a message to the logs if no bundle has been found
         # that's non-breaking and expected for most roles
-        p "No bundle with ipsets (#{bundle}) in Consul. This might be expected."
+        p "testsava: No bundle with ipsets (#{bundle}) in Consul. This might be expected."
 
         # return empty hash
         {}


### PR DESCRIPTION
- Add resilience for trailing and leading whitespaces in IPs
- Move logging messages outside of error log on the puppet master

More info on how the implementation has been tested in the ticket comments:
https://bedegaming.atlassian.net/browse/FAB-1009